### PR TITLE
Let the adapter differentiate aliases from the normal method

### DIFF
--- a/lib/Log/Any/Adapter/Base.pm
+++ b/lib/Log/Any/Adapter/Base.pm
@@ -28,6 +28,18 @@ for my $method ( Log::Any::Adapter::Util::logging_and_detection_methods() ) {
     };
 }
 
+# Create relay method for each alias
+{
+    my %aliases = Log::Any::Adapter::Util::log_level_aliases();
+    for (keys %aliases) {
+        my $dest    = $aliases{$_};
+        my $is_dest = "is_$dest";
+        no strict 'refs';
+        *$_        = sub { goto $_[0]->can($dest) };
+        *{"is_$_"} = sub { goto $_[0]->can($is_dest) };
+    }
+}
+
 # This methods installs a method that delegates to an object attribute
 sub delegate_method_to_slot {
     my ( $class, $slot, $method, $adapter_method ) = @_;

--- a/lib/Log/Any/Proxy.pm
+++ b/lib/Log/Any/Proxy.pm
@@ -48,15 +48,13 @@ my %aliases = Log::Any::Adapter::Util::log_level_aliases();
 # Set up methods/aliases and detection methods/aliases
 foreach my $name ( Log::Any::Adapter::Util::logging_methods(), keys(%aliases) )
 {
-    my $realname    = $aliases{$name} || $name;
     my $namef       = $name . "f";
     my $is_name     = "is_$name";
-    my $is_realname = "is_$realname";
-    my $numeric     = Log::Any::Adapter::Util::numeric_level($realname);
+    my $numeric     = Log::Any::Adapter::Util::numeric_level($name);
     no strict 'refs';
     *{$is_name} = sub {
         my ($self) = @_;
-        return $self->{adapter}->$is_realname;
+        return $self->{adapter}->$is_name;
     };
     *{$name} = sub {
         my ( $self, @parts ) = @_;
@@ -67,11 +65,11 @@ foreach my $name ( Log::Any::Adapter::Util::logging_methods(), keys(%aliases) )
         return unless defined $message and length $message;
         $message = "$self->{prefix}$message"
           if defined $self->{prefix} && length $self->{prefix};
-        return $self->{adapter}->$realname($message);
+        return $self->{adapter}->$name($message);
     };
     *{$namef} = sub {
         my ( $self, @args ) = @_;
-        return unless $self->{adapter}->$is_realname;
+        return unless $self->{adapter}->$is_name;
         my $message =
           $self->{formatter}->( $self->{category}, $numeric, @args );
         return unless defined $message and length $message;

--- a/t/inner-adapter.t
+++ b/t/inner-adapter.t
@@ -2,7 +2,7 @@ use strict;
 use warnings;
 use Test::More;
 
-plan tests => 2;
+plan tests => 4;
 
 our $BUF;
 
@@ -26,3 +26,14 @@ my $log = Log::Any->get_logger;
 
 $log->critical("DIE DIE DIE");
 is( $BUF, "DIE DIE DIE\n", "logged a message via inner adapter" );
+
+# Test that we can change methods at runtime and it still works,
+# and test that aliases can be overridden separate from the main method.
+{
+    no warnings 'once';
+    no warnings 'redefine';
+    local *MyApp::Log::Adapter::fatal= sub { 1 };
+    local *MyApp::Log::Adapter::critical= sub { 2 };
+    is( $log->critical('foo'), 2, 'dispatching dynamically by name' );
+    is( $log->fatal('foo'),    1, 'differentiate fatal from critical' );
+}


### PR DESCRIPTION
How does this look?  I'm passing all aliases to the adapter, and the default relaying methods use goto &coderef which should be the lowest overhead.

I passed all aliases for consistency, though the only one I really care about is fatal().