### PR TITLE
better diag for does_not_contain_ok

### DIFF
--- a/lib/Log/Any/Adapter/Test.pm
+++ b/lib/Log/Any/Adapter/Test.pm
@@ -116,7 +116,7 @@ sub does_not_contain_ok {
       _first_index( sub { $_->{message} =~ /$regex/ }, @{ $self->msgs } );
     if ( $found != -1 ) {
         $tb->ok( 0, $test_name );
-        $tb->diag( "found message matching $regex: " . $self->msgs->[$found] );
+        $tb->diag( "found message matching $regex: " . $self->msgs->[$found]->{message} );
     }
     else {
         $tb->ok( 1, $test_name );


### PR DESCRIPTION
that will show the actual message instead of HASH(0x........)