### PR TITLE
fix duplicated documentation sections

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -9,7 +9,6 @@ copyright_holder = Jonathan Swartz and David Golden
 [@DAGOLDEN]
 :version = 0.072
 MetaNoIndex.package[0] = Log::Any::Manager::_Guard
--remove = PodWeaver
 authority = cpan:JSWARTZ
 no_coverage = 1
 stopwords = alertf
@@ -30,12 +29,6 @@ stopwords = tracef
 stopwords = tranformed
 stopwords = warnf
 stopwords = warningf
-
-[SurgicalPodWeaver]
-:version = 0.0021
-config_plugin = @DAGOLDEN
-replacer = replace_with_comment
-post_code_replacer = replace_with_nothing
 
 [OnlyCorePrereqs]
 :version = 0.003


### PR DESCRIPTION
It seems the DAGOLDEN plugin bundle got updated to add SurgicalPodWeaver
instead of PodWeaver. Since this dist.ini already had it, some sections
of the docs showed up twice.